### PR TITLE
feat: Implement chat endpoint for language model API

### DIFF
--- a/lms-api/src/chat.rs
+++ b/lms-api/src/chat.rs
@@ -1,0 +1,179 @@
+use tracing::info;
+use crate::chat::request::{ChatRequest, Input};
+use crate::chat::response::ChatResponse;
+use crate::error::ApiError;
+use crate::LmStudio;
+
+impl LmStudio {
+    pub async fn chat(&self, model: &str, input: &str) -> Result<ChatResponse, ApiError> {
+        info!("Send a message to model");
+
+        let url = format!("{}api/v1/chat", self.url);
+
+        let json = ChatRequest::new(model, input);
+
+        let res = self.client.post(url).json(&json).send().await?;
+
+        if !res.status().is_success() {
+            return Err(ApiError::Status(res.status()));
+        }
+
+        let response = res.json::<ChatResponse>().await?;
+
+        Ok(response)
+    }
+}
+
+mod request {
+    use crate::types::AllowedOptions;
+    use serde::Serialize;
+    use std::collections::HashMap;
+
+    #[derive(Serialize)]
+    pub struct ChatRequest {
+        model: String,
+        input: Input,
+        system_prompt: Option<String>,
+        integrations: Option<Integration>,
+        stream: Option<bool>,
+        temperature: Option<f64>,
+        top_p: Option<f64>,
+        top_k: Option<u32>,
+        min_p: Option<f64>,
+        repeat_penalty: Option<f64>,
+        max_output_tokens: Option<u32>,
+        reasoning: Option<AllowedOptions>,
+        context_length: Option<u32>,
+        store: Option<bool>,
+        previous_response_id: Option<String>,
+    }
+
+    impl ChatRequest {
+        pub fn new(model: &str, input: &str) -> Self {
+            Self {
+                model: model.to_string(),
+                input: Input::InputText(input.to_string()),
+                system_prompt: None,
+                integrations: None,
+                stream: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                min_p: None,
+                repeat_penalty: None,
+                max_output_tokens: None,
+                reasoning: None,
+                context_length: None,
+                store: None,
+                previous_response_id: None,
+            }
+        }
+    }
+
+    #[derive(Serialize)]
+    pub(super) enum Input {
+        InputText(String),
+        InputObject(InputObject),
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum InputObject {
+        Message {
+            content: String,
+        },
+        Image {
+            data_url: String,
+        }
+    }
+
+
+    #[derive(Serialize)]
+    enum Integration {
+        PluginId(String),
+        Integration(Tagged),
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum Tagged {
+        Plugin {
+            id: String,
+            allowed_tools: Option<Vec<String>>,
+        },
+        EphemeralMcp {
+            server_label: String,
+            server_url: String,
+            allowed_tools: Option<Vec<String>>,
+            headers: Option<HashMap<String, String>>,
+        }
+    }
+}
+
+mod response {
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Deserialize)]
+    pub struct ChatResponse {
+        model_instance_id: String,
+        output: Vec<Output>,
+        stats: Stats,
+        response_id: Option<String>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum Output {
+        Message {
+            content: String,
+        },
+        ToolCall {
+            tool: String,
+            arguments: HashMap<String, String>,
+            output: String,
+            provider_info: ProviderInfo,
+        },
+        Reasoning {
+            content: String,
+        },
+        InvalidToolCall {
+            reason: String,
+            metadata: Metadata
+        },
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "type")]
+    enum ProviderInfo {
+        Plugin {
+            plugin_id: String,
+        },
+        EphemeralMcp {
+            server_label: String,
+        }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(tag = "type")]
+    enum Metadata {
+        InvalidName {
+            tool_name: String,
+        },
+        InvalidArguments {
+            tool_name: String,
+            arguments: HashMap<String, String>,
+            provider_info: ProviderInfo
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct Stats {
+        input_tokens : f64,
+        total_output_tokens : f64,
+        reasoning_output_tokens : f64,
+        tokens_per_second : f64,
+        time_to_first_token_seconds : f64,
+        model_load_time_seconds : Option<f64>
+    }
+}

--- a/lms-api/src/lib.rs
+++ b/lms-api/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod error;
 pub mod models;
+pub mod chat;
+pub mod types;
 
 use reqwest::{Client, IntoUrl, Url};
 use std::time::Duration;

--- a/lms-api/src/models.rs
+++ b/lms-api/src/models.rs
@@ -1,14 +1,13 @@
 pub mod download;
 pub mod download_status;
 pub mod load;
-pub mod types;
 pub mod unload;
 
 use crate::LmStudio;
 use crate::error::ApiError;
 use serde::Deserialize;
 use tracing::{info, instrument};
-use types::ModelType;
+use crate::types::{AllowedOptions, ModelFileFormat, ModelType};
 
 impl LmStudio {
     #[instrument(skip(self))]
@@ -77,16 +76,6 @@ pub struct Config {
 }
 
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum ModelFileFormat {
-    Gguf,
-    Mlx,
-
-    #[serde(other)]
-    Unknown,
-}
-
-#[derive(Deserialize, Debug)]
 pub struct Capability {
     pub vision: bool,
     pub trained_for_tool_use: bool,
@@ -97,17 +86,4 @@ pub struct Capability {
 pub struct Reasoning {
     pub allowed_options: Vec<AllowedOptions>,
     pub default: AllowedOptions,
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum AllowedOptions {
-    Off,
-    On,
-    Low,
-    Medium,
-    High,
-
-    #[serde(other)]
-    Unknown,
 }

--- a/lms-api/src/models/download.rs
+++ b/lms-api/src/models/download.rs
@@ -1,6 +1,6 @@
 use crate::LmStudio;
 use crate::error::ApiError;
-use crate::models::types::DownloadStatus;
+use crate::types::DownloadStatus;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 

--- a/lms-api/src/models/download_status.rs
+++ b/lms-api/src/models/download_status.rs
@@ -1,6 +1,6 @@
 use crate::LmStudio;
 use crate::error::ApiError;
-use crate::models::types::DownloadStatus;
+use crate::types::DownloadStatus;
 use serde::Deserialize;
 
 impl LmStudio {

--- a/lms-api/src/models/load.rs
+++ b/lms-api/src/models/load.rs
@@ -1,6 +1,6 @@
 use crate::LmStudio;
 use crate::error::ApiError;
-use crate::models::types::{LoadStatus, ModelType};
+use crate::types::{LoadStatus, ModelType};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 

--- a/lms-api/src/types.rs
+++ b/lms-api/src/types.rs
@@ -1,5 +1,15 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelFileFormat {
+    Gguf,
+    Mlx,
+
+    #[serde(other)]
+    Unknown,
+}
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -38,6 +48,19 @@ pub enum DownloadStatus {
 #[serde(rename_all = "snake_case")]
 pub enum LoadStatus {
     Loaded,
+
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum AllowedOptions {
+    Off,
+    On,
+    Low,
+    Medium,
+    High,
 
     #[serde(other)]
     Unknown,


### PR DESCRIPTION
Added core chat functionality to communicate with the model via chat/v1 endpoint. This includes structured handling for requests, responses, and tool calls. Refactors model-related types (e.g., `ModelFileFormat`) into `src/types.rs`.