### PR TITLE
refactor(lms-api): overhaul API client for better safety and maintainability

### DIFF
--- a/lms-api/Cargo.toml
+++ b/lms-api/Cargo.toml
@@ -4,10 +4,21 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-stream = { version = "0.3", optional = true }
 derive_builder = "0.20.2"
 reqwest = { version = "0.13", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["sync"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
 tracing = "0.1"
+url = "2.5"
+
+[dev-dependencies]
+mockito = "1.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = []
+stream = ["tokio", "tokio-stream", "async-stream", "reqwest/stream"]

--- a/lms-api/src/chat.rs
+++ b/lms-api/src/chat.rs
@@ -1,27 +1,20 @@
+pub mod stream;
+
 use crate::LmStudio;
-use crate::chat::request::{ChatRequest, ChatRequestBuilder};
+use crate::chat::request::ChatRequest;
 use crate::chat::response::ChatResponse;
 use crate::error::ApiError;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self, request), fields(url = %self.url, endpoint = "/api/v1/chat", model = request.model))]
     pub async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, ApiError> {
         info!("Send a message to a model and receive a response. Supports MCP integration.");
 
-        let url = format!("{}api/v1/chat", self.url);
-        let res = self.client.post(&url).json(&request).send().await?;
+        let url = self.endpoint("api/v1/chat")?;
+        let res = self.client.post(url).json(&request).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let response = res.json::<ChatResponse>().await?;
-        Ok(response)
+        self.handle_response(res).await
     }
 }
 
@@ -44,7 +37,7 @@ pub mod request {
         #[builder(default)]
         integrations: Option<Integration>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        #[builder(default)]
+        #[builder(setter(skip), default)]
         stream: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[builder(default)]
@@ -78,6 +71,13 @@ pub mod request {
         previous_response_id: Option<String>,
     }
 
+    impl ChatRequest {
+        pub(super) fn with_stream(mut self, value: bool) -> Self {
+            self.stream = Some(value);
+            self
+        }
+    }
+
     #[derive(Serialize, Clone)]
     #[serde(untagged)]
     pub enum Input {
@@ -101,7 +101,7 @@ pub mod request {
 
     #[derive(Serialize, Clone)]
     #[serde(tag = "type")]
-    pub(super) enum InputObject {
+    pub enum InputObject {
         Message { content: String },
         Image { data_url: String },
     }

--- a/lms-api/src/chat/stream.rs
+++ b/lms-api/src/chat/stream.rs
@@ -1,0 +1,168 @@
+use crate::LmStudio;
+use crate::chat::request::ChatRequest;
+use crate::chat::stream::response::StreamEvent;
+use crate::error::ApiError;
+use async_stream::stream;
+use tokio_stream::{Stream, StreamExt};
+use tracing::{debug, error, info, instrument};
+
+#[cfg(feature = "stream")]
+impl LmStudio {
+    #[instrument(skip(self, request), fields(url = %self.url, endpoint = "/api/v1/chat", model = request.model))]
+    pub async fn chat_stream(
+        &self,
+        request: ChatRequest,
+    ) -> Result<impl Stream<Item = Result<StreamEvent, ApiError>>, ApiError> {
+        info!("Send a message to a model and receive a response. Supports MCP integration.");
+
+        let url = self.endpoint("api/v1/chat")?;
+        let request = request.with_stream(true);
+        let res = self.client.post(url).json(&request).send().await?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(ApiError::Status(status, body));
+        }
+
+        let s = stream! {
+            let mut buffer = Vec::new();
+            let mut stream = res.bytes_stream();
+
+            while let Some(chunk_result) = stream.next().await {
+                match chunk_result {
+                    Ok(chunk) => {
+                        buffer.extend_from_slice(&chunk);
+
+                        while let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+                            let line_bytes = buffer[..pos].to_vec();
+                            buffer.drain(..pos + 1);
+
+                            let line = String::from_utf8_lossy(&line_bytes);
+                            let line = line.trim();
+
+                            if line.is_empty() {
+                                continue;
+                            }
+
+                            if let Some(ev) = line.strip_prefix("event:") {
+                                debug!(event = %ev.trim(), "SSE event type");
+                            } else if let Some(data) = line.strip_prefix("data:") {
+                                let data = data.trim();
+                                if data == "[DONE]" {
+                                    return;
+                                }
+
+                                match serde_json::from_str::<StreamEvent>(data) {
+                                    Ok(response) => yield Ok(response),
+                                    Err(e) => {
+                                        error!(error = %e, data = %data, "Failed to deserialize response");
+                                        yield Err(ApiError::Other(format!("Deserialization error: {}", e)));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Failed to read response");
+                        yield Err(ApiError::Request(e));
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "stream")]
+pub mod response {
+    use crate::chat::response::{ChatResponse, Metadata, ProviderInfo};
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "type")]
+    pub enum StreamEvent {
+        /// An event that is emitted at the start of a chat response stream.
+        #[serde(rename = "chat.start")]
+        ChatStart { model_instance_id: String },
+        /// Signals the start of a model being loaded to fulfill the chat request. Will not be emitted if the requested model is already loaded.
+        #[serde(rename = "model_load.start")]
+        ModelLoadStart { model_instance_id: String },
+        #[serde(rename = "model_load.progress")]
+        ModelLoadProgress {
+            model_instance_id: String,
+            progress: f64,
+        },
+        #[serde(rename = "model_load.end")]
+        ModelLoadEnd {
+            model_instance_id: String,
+            load_time_seconds: f64,
+        },
+        #[serde(rename = "prompt_processing.start")]
+        PromptProcessingStart,
+        #[serde(rename = "prompt_processing.progress")]
+        PromptProcessingProgress { progress: f64 },
+        #[serde(rename = "prompt_processing.end")]
+        PromptProcessingEnd,
+        #[serde(rename = "reasoning.start")]
+        ReasoningStart,
+        #[serde(rename = "reasoning.delta")]
+        ReasoningDelta { content: String },
+        #[serde(rename = "reasoning.end")]
+        ReasoningEnd,
+        #[serde(rename = "tool_call.start")]
+        ToolCallStart {
+            tool: String,
+            provider_info: ProviderInfo,
+        },
+        #[serde(rename = "tool_call.arguments")]
+        ToolCallArguments {
+            tool: String,
+            arguments: HashMap<String, String>,
+            provider_info: ProviderInfo,
+        },
+        #[serde(rename = "tool_call.success")]
+        ToolCallSuccess {
+            tool: String,
+            arguments: HashMap<String, String>,
+            output: String,
+            provider_info: ProviderInfo,
+        },
+        #[serde(rename = "tool_call.failure")]
+        ToolCallFailure { reason: String, metadata: Metadata },
+        #[serde(rename = "message.start")]
+        MessageStart,
+        #[serde(rename = "message.delta")]
+        MessageDelta { content: String },
+        #[serde(rename = "message.end")]
+        MessageEnd,
+        #[serde(rename = "error")]
+        Error { error: StreamError },
+        #[serde(rename = "chat.end")]
+        ChatEnd { result: ChatResponse },
+    }
+
+    #[derive(Deserialize, Debug)]
+    pub struct StreamError {
+        error_type: ErrorType,
+        message: String,
+        code: Option<String>,
+        param: Option<String>,
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "snake_case")]
+    enum ErrorType {
+        InvalidRequest,
+        Unknown,
+        McpConnectionError,
+        PluginConnectionError,
+        NotImplemented,
+        ModelNotFound,
+        JobNotFound,
+        InternalError,
+    }
+}

--- a/lms-api/src/error.rs
+++ b/lms-api/src/error.rs
@@ -6,6 +6,15 @@ pub enum ApiError {
     #[error("request failed: {0}")]
     Request(#[from] reqwest::Error),
 
+    #[error("invalid url: {0}")]
+    Url(#[from] url::ParseError),
+
+    #[error("invalid configuration: {0}")]
+    Config(String),
+
     #[error("unexpected status: {0}")]
     Status(StatusCode, String),
+
+    #[error("unexpected error: {0}")]
+    Other(String),
 }

--- a/lms-api/src/lib.rs
+++ b/lms-api/src/lib.rs
@@ -3,7 +3,10 @@ pub mod error;
 pub mod models;
 pub mod types;
 
-use reqwest::{Client, IntoUrl, Url};
+use crate::error::ApiError;
+use reqwest::{Client, IntoUrl, Response, Url};
+use serde::de::DeserializeOwned;
+use std::time::Duration;
 
 pub struct LmStudio {
     url: Url,
@@ -11,32 +14,53 @@ pub struct LmStudio {
 }
 
 impl LmStudio {
-    pub fn new(host: impl IntoUrl, port: u16) -> Self {
-        let mut url = host.into_url().unwrap();
+    pub fn new(host: impl IntoUrl, port: u16) -> Result<Self, ApiError> {
+        let mut url = host
+            .into_url()
+            .map_err(|e| ApiError::Config(e.to_string()))?;
 
-        url.set_port(Some(port)).unwrap();
+        url.set_port(Some(port))
+            .map_err(|_| ApiError::Config("Could not set port".to_string()))?;
 
-        Self::from_url(url)
+        Ok(Self::from_url(url))
     }
 
-    fn from_url(url: Url) -> Self {
-        Self {
-            url,
-            ..Default::default()
+    pub fn from_url(url: Url) -> Self {
+        let client = Client::builder().build().unwrap_or_default();
+
+        Self { url, client }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.client = Client::builder()
+            .timeout(timeout)
+            .build()
+            .unwrap_or_default();
+        self
+    }
+
+    pub fn with_client(mut self, client: Client) -> Self {
+        self.client = client;
+        self
+    }
+
+    async fn handle_response<T: DeserializeOwned>(&self, res: Response) -> Result<T, ApiError> {
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(ApiError::Status(status, body));
         }
+
+        Ok(res.json::<T>().await?)
+    }
+
+    fn endpoint(&self, path: &str) -> Result<Url, ApiError> {
+        self.url.join(path).map_err(ApiError::Url)
     }
 }
 
 impl Default for LmStudio {
     fn default() -> Self {
-        let client = Client::builder()
-            // .timeout(Duration::from_secs(30))
-            .build()
-            .unwrap();
-
-        Self {
-            url: Url::parse("http://localhost:1234").unwrap(),
-            client,
-        }
+        Self::from_url(Url::parse("http://localhost:1234").expect("Valid default URL"))
     }
 }

--- a/lms-api/src/models.rs
+++ b/lms-api/src/models.rs
@@ -6,7 +6,7 @@ pub mod unload;
 use crate::LmStudio;
 use crate::error::ApiError;
 use crate::models::response::{Model, ModelsResponse};
-use tracing::{error, info, instrument, warn};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self), fields(url = %self.url, endpoint = "/api/v1/models"))]
@@ -15,18 +15,10 @@ impl LmStudio {
             "Get a list of available models on your system, including both LLMs and embedding models."
         );
 
-        let url = format!("{}api/v1/models", self.url);
-        let res = self.client.get(&url).send().await?;
+        let url = self.endpoint("api/v1/models")?;
+        let res = self.client.get(url).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let models = res.json::<ModelsResponse>().await?;
+        let models = self.handle_response::<ModelsResponse>(res).await?;
         Ok(models.models)
     }
 }

--- a/lms-api/src/models/download.rs
+++ b/lms-api/src/models/download.rs
@@ -2,26 +2,17 @@ use crate::LmStudio;
 use crate::error::ApiError;
 use crate::models::download::request::DownloadRequest;
 use crate::models::download::response::DownloadResponse;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self), fields(url = %self.url, endpoint = "/api/v1/models/download"))]
     pub async fn download(&self, request: DownloadRequest) -> Result<DownloadResponse, ApiError> {
         info!("Download LLMs and embedding models");
 
-        let url = format!("{}api/v1/models/download", self.url);
-        let res = self.client.post(&url).json(&request).send().await?;
+        let url = self.endpoint("api/v1/models/download")?;
+        let res = self.client.post(url).json(&request).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let response = res.json::<DownloadResponse>().await?;
-        Ok(response)
+        self.handle_response(res).await
     }
 }
 

--- a/lms-api/src/models/download_status.rs
+++ b/lms-api/src/models/download_status.rs
@@ -1,26 +1,18 @@
 use crate::LmStudio;
 use crate::error::ApiError;
 use crate::models::download_status::response::DownloadStatusResponse;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self), fields(url = %self.url, endpoint = "/api/v1/models/download/status/{job_id}"))]
     pub async fn download_status(&self, job_id: &str) -> Result<DownloadStatusResponse, ApiError> {
         info!("Get the status of model downloads");
 
-        let url = format!("{}api/v1/models/download/status/{job_id}", self.url);
-        let res = self.client.get(&url).send().await?;
+        let path = format!("api/v1/models/download/status/{job_id}");
+        let url = self.endpoint(&path)?;
+        let res = self.client.get(url).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let response = res.json::<DownloadStatusResponse>().await?;
-        Ok(response)
+        self.handle_response(res).await
     }
 }
 

--- a/lms-api/src/models/load.rs
+++ b/lms-api/src/models/load.rs
@@ -2,26 +2,17 @@ use crate::LmStudio;
 use crate::error::ApiError;
 use crate::models::load::request::LoadRequest;
 use crate::models::load::response::LoadResponse;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self, request), fields(url = %self.url, endpoint = "/api/v1/models/load", model = %request.model))]
     pub async fn load(&self, request: LoadRequest) -> Result<LoadResponse, ApiError> {
         info!("Load an LLM or Embedding model into memory with custom configuration for inference");
 
-        let url = format!("{}api/v1/models/load", self.url);
-        let res = self.client.post(&url).json(&request).send().await?;
+        let url = self.endpoint("api/v1/models/load")?;
+        let res = self.client.post(url).json(&request).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let response = res.json::<LoadResponse>().await?;
-        Ok(response)
+        self.handle_response(res).await
     }
 }
 

--- a/lms-api/src/models/unload.rs
+++ b/lms-api/src/models/unload.rs
@@ -2,26 +2,18 @@ use crate::LmStudio;
 use crate::error::ApiError;
 use crate::models::unload::request::UnloadRequest;
 use crate::models::unload::response::UnloadResponse;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 impl LmStudio {
     #[instrument(skip(self), fields(url = %self.url, endpoint = "/api/v1/models/unload"))]
     pub async fn unload(&self, instance_id: &str) -> Result<String, ApiError> {
         info!("Unload a loaded model from memory");
 
-        let url = format!("{}api/v1/models/unload", self.url);
+        let url = self.endpoint("api/v1/models/unload")?;
         let json = UnloadRequest::new(instance_id);
-        let res = self.client.post(&url).json(&json).send().await?;
+        let res = self.client.post(url).json(&json).send().await?;
 
-        let status = res.status();
-        if !status.is_success() {
-            error!(%url, "LM Studio request failed");
-
-            let body = res.text().await.unwrap_or_default();
-            return Err(ApiError::Status(status, body));
-        }
-
-        let response = res.json::<UnloadResponse>().await?;
+        let response = self.handle_response::<UnloadResponse>(res).await?;
         Ok(response.instance_id)
     }
 }

--- a/lms-api/tests/integration.rs
+++ b/lms-api/tests/integration.rs
@@ -1,0 +1,45 @@
+use lms_api::LmStudio;
+use mockito::Server;
+use url::Url;
+
+#[tokio::test]
+async fn test_models_list() {
+    let mut server = Server::new_async().await;
+    let url = server.url();
+    
+    let _m = server.mock("GET", "/api/v1/models")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"models": [{"type": "llm", "publisher": "test", "key": "test-model", "display_name": "Test Model", "size_bytes": 1024, "loaded_instances": [], "max_context_length": 2048}]}"#)
+        .create_async()
+        .await;
+
+    let client = LmStudio::from_url(Url::parse(&url).unwrap());
+    let models = client.models().await.unwrap();
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].key, "test-model");
+}
+
+#[tokio::test]
+async fn test_error_handling() {
+    let mut server = Server::new_async().await;
+    let url = server.url();
+    
+    let _m = server.mock("GET", "/api/v1/models")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .create_async()
+        .await;
+
+    let client = LmStudio::from_url(Url::parse(&url).unwrap());
+    let result = client.models().await;
+
+    assert!(result.is_err());
+    if let Err(lms_api::error::ApiError::Status(status, body)) = result {
+        assert_eq!(status, 500);
+        assert_eq!(body, "Internal Server Error");
+    } else {
+        panic!("Expected Status error");
+    }
+}


### PR DESCRIPTION
This squash commit consolidates several improvements to the lms-api library:
- Safety: Removed panics (unwraps) in LmStudio initialization and added Result-based error handling.
- Maintainability: Abstracted common request/response logic and URL construction into helper methods, significantly reducing code duplication across all endpoints.
- Flexibility: Added with_timeout() and with_client() to allow custom HTTP configurations.
- Robustness: Improved SSE streaming logic and expanded ApiError with more descriptive variants.
- Quality: Optimized dependencies (removed tokio/full) and added a new integration test suite using mockito.