### PR TITLE
feat: add support for LLM thinking/reasoning options

### DIFF
--- a/kommit/src/cli.rs
+++ b/kommit/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::prompt::ResponseLang;
-use crate::provider::LlmProvider;
+use crate::provider::{LlmProvider, ThinkType};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -19,6 +19,9 @@ pub(crate) struct Args {
     #[arg(long, default_value_t = LlmProvider::Ollama)]
     pub(crate) provider: LlmProvider,
 
-    #[arg(long)]
+    #[arg(short, long)]
     pub(crate) stream: bool,
+
+    #[arg(short, long)]
+    pub(crate) think: Option<ThinkType>,
 }

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -8,6 +8,7 @@ use crate::prompt::build_prompt;
 use crate::provider::{StreamResponse, create_client};
 use clap::Parser;
 use futures::StreamExt;
+use owo_colors::OwoColorize;
 use std::io;
 use std::io::Write;
 use tracing::info;
@@ -26,12 +27,18 @@ async fn main() -> anyhow::Result<()> {
     let prompt = build_prompt(&diff, args.lang);
 
     if args.stream {
-        let mut stream = client.generate_stream(&args.model, &prompt).await?;
+        let mut stream = client
+            .generate_stream(&args.model, &prompt, args.think)
+            .await?;
 
         let mut out = io::stdout().lock();
         while let Some(res) = stream.next().await {
             match res? {
-                StreamResponse::Think(text) | StreamResponse::Generate(text) => {
+                StreamResponse::Think(text) => {
+                    out.write_all(text.bright_black().to_string().as_bytes())?;
+                    out.flush()?;
+                }
+                StreamResponse::Generate(text) => {
                     out.write_all(text.as_bytes())?;
                     out.flush()?;
                 }
@@ -39,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
         }
         writeln!(out)?;
     } else {
-        let message = client.generate(&args.model, &prompt).await?;
+        let message = client.generate(&args.model, &prompt, args.think).await?;
         println!("{message}");
     }
 

--- a/kommit/src/provider.rs
+++ b/kommit/src/provider.rs
@@ -30,13 +30,38 @@ pub(crate) type LlmStream = Pin<Box<dyn Stream<Item = anyhow::Result<StreamRespo
 
 #[async_trait]
 pub(crate) trait LlmClient {
-    async fn generate(&self, model: &str, prompt: &str) -> anyhow::Result<String>;
-    async fn generate_stream(&self, model: &str, prompt: &str) -> anyhow::Result<LlmStream>;
+    async fn generate(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<String>;
+    async fn generate_stream(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<LlmStream>;
 }
 
 pub(crate) fn create_client(provider: LlmProvider) -> Box<dyn LlmClient> {
     match provider {
         LlmProvider::Ollama => Box::new(OllamaClient::new()),
         LlmProvider::LmStudio => Box::new(LmStudioClient::new()),
+    }
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub(crate) enum ThinkType {
+    True,
+    False,
+    Low,
+    Medium,
+    High,
+}
+
+impl Display for ThinkType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_possible_value().unwrap().get_name())
     }
 }

--- a/kommit/src/provider/lmstudio.rs
+++ b/kommit/src/provider/lmstudio.rs
@@ -1,4 +1,4 @@
-use crate::provider::{LlmClient, LlmStream, StreamResponse};
+use crate::provider::{LlmClient, LlmStream, StreamResponse, ThinkType};
 use anyhow::Context;
 use async_stream::stream;
 use async_trait::async_trait;
@@ -7,7 +7,6 @@ use lms_api::LmStudio;
 use lms_api::chat::request::ChatRequestBuilder;
 use lms_api::chat::response::Output;
 use lms_api::chat::stream::response::StreamEvent;
-use owo_colors::OwoColorize;
 use std::fmt::Write;
 use tracing::{info, instrument, trace};
 
@@ -22,19 +21,23 @@ impl LmStudioClient {
 #[async_trait]
 impl LlmClient for LmStudioClient {
     #[instrument(skip(self, prompt))]
-    async fn generate(&self, model: &str, prompt: &str) -> anyhow::Result<String> {
-        info!("Generating message");
+    async fn generate(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<String> {
+        info!("Generating commit message");
         trace!(prompt = prompt, "Generating commit message");
 
         let lms = LmStudio::default();
+        let mut builder = ChatRequestBuilder::default();
+        if let Some(think_type) = think {
+            builder.reasoning(think_type);
+        }
 
         let res = lms
-            .chat(
-                ChatRequestBuilder::default()
-                    .model(model)
-                    .input(prompt)
-                    .build()?,
-            )
+            .chat(builder.model(model).input(prompt).build()?)
             .await
             .context("Failed to connect to LmStudio. Is it running?")?;
 
@@ -57,19 +60,23 @@ impl LlmClient for LmStudioClient {
     }
 
     #[instrument(skip(self, prompt))]
-    async fn generate_stream(&self, model: &str, prompt: &str) -> anyhow::Result<LlmStream> {
-        info!("Generating message");
+    async fn generate_stream(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<LlmStream> {
+        info!("Generating commit message");
         trace!(prompt = prompt, "Generating commit message");
 
         let lms = LmStudio::default();
+        let mut builder = ChatRequestBuilder::default();
+        if let Some(think_type) = think {
+            builder.reasoning(think_type);
+        }
 
         let mut stream = lms
-            .chat_stream(
-                ChatRequestBuilder::default()
-                    .model(model)
-                    .input(prompt)
-                    .build()?,
-            )
+            .chat_stream(builder.model(model).input(prompt).build()?)
             .await
             .context("Failed to connect to LmStudio. Is it running?")?;
 
@@ -89,7 +96,7 @@ impl LlmClient for LmStudioClient {
                     StreamEvent::ReasoningDelta { content } => {
                         info!(content = %content, event = "reasoning.delta");
 
-                        yield Ok(StreamResponse::Think(content.bright_black().to_string()));
+                        yield Ok(StreamResponse::Think(content));
                     }
                     StreamEvent::ReasoningEnd => {
 
@@ -98,7 +105,7 @@ impl LlmClient for LmStudioClient {
                     StreamEvent::MessageDelta { content } => {
                         info!(content = %content, event = "message.delta");
 
-                        yield Ok(StreamResponse::Generate(content.to_string()));
+                        yield Ok(StreamResponse::Generate(content));
                     }
                     _ => continue,
                 }
@@ -106,5 +113,17 @@ impl LlmClient for LmStudioClient {
         };
 
         Ok(Box::pin(s))
+    }
+}
+
+impl From<ThinkType> for lms_api::types::AllowedOptions {
+    fn from(value: ThinkType) -> Self {
+        match value {
+            ThinkType::True => lms_api::types::AllowedOptions::On,
+            ThinkType::False => lms_api::types::AllowedOptions::Off,
+            ThinkType::Low => lms_api::types::AllowedOptions::Low,
+            ThinkType::Medium => lms_api::types::AllowedOptions::Medium,
+            ThinkType::High => lms_api::types::AllowedOptions::High,
+        }
     }
 }

--- a/kommit/src/provider/ollama.rs
+++ b/kommit/src/provider/ollama.rs
@@ -1,4 +1,4 @@
-use crate::provider::{LlmClient, LlmStream, StreamResponse};
+use crate::provider::{LlmClient, LlmStream, StreamResponse, ThinkType};
 use anyhow::Context;
 use async_stream::stream;
 use async_trait::async_trait;
@@ -17,27 +17,48 @@ impl OllamaClient {
 
 #[async_trait]
 impl LlmClient for OllamaClient {
-    #[instrument(skip(self, model, prompt))]
-    async fn generate(&self, model: &str, prompt: &str) -> anyhow::Result<String> {
-        info!(%model, "Generating message");
-        trace!(model = model, prompt = prompt, "Generating commit message");
-        // TODO: stream 지원 -> UX 개선 가능
+    #[instrument(skip(self, prompt))]
+    async fn generate(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<String> {
+        info!("Generating commit message");
+        trace!(prompt = prompt, "Generating commit message");
 
         let ollama = Ollama::default();
+        let mut request = GenerationRequest::new(model.to_string(), prompt);
+        if let Some(think_type) = think {
+            request = request.think(think_type);
+        }
 
         let res = ollama
-            .generate(GenerationRequest::new(model.to_string(), prompt))
+            .generate(request)
             .await
             .context("Failed to connect to Ollama. Is it running?")?;
 
         Ok(res.response)
     }
 
-    async fn generate_stream(&self, model: &str, prompt: &str) -> anyhow::Result<LlmStream> {
+    #[instrument(skip(self, prompt))]
+    async fn generate_stream(
+        &self,
+        model: &str,
+        prompt: &str,
+        think: Option<ThinkType>,
+    ) -> anyhow::Result<LlmStream> {
+        info!("Generating commit message stream");
+        trace!(prompt = prompt, "Generating commit message stream");
+
         let ollama = Ollama::default();
+        let mut request = GenerationRequest::new(model.to_string(), prompt);
+        if let Some(think_type) = think {
+            request = request.think(think_type);
+        }
 
         let stream = ollama
-            .generate_stream(GenerationRequest::new(model.to_string(), prompt))
+            .generate_stream(request)
             .await
             .context("Failed to connect to Ollama. Is it running?")?;
 
@@ -48,7 +69,11 @@ impl LlmClient for OllamaClient {
                 match res {
                     Ok(responses) => {
                         for res in responses {
-                            yield Ok(StreamResponse::Generate(res.response));
+                            if let Some(thinking) = res.thinking {
+                                yield Ok(StreamResponse::Think(thinking));
+                            } else {
+                                yield Ok(StreamResponse::Generate(res.response));
+                            }
                         }
                     }
                     Err(e) => yield Err(anyhow::anyhow!(e)),
@@ -57,5 +82,17 @@ impl LlmClient for OllamaClient {
         };
 
         Ok(Box::pin(s))
+    }
+}
+
+impl From<ThinkType> for ollama_rs::generation::parameters::ThinkType {
+    fn from(value: ThinkType) -> Self {
+        match value {
+            ThinkType::True => ollama_rs::generation::parameters::ThinkType::True,
+            ThinkType::False => ollama_rs::generation::parameters::ThinkType::False,
+            ThinkType::Low => ollama_rs::generation::parameters::ThinkType::Low,
+            ThinkType::Medium => ollama_rs::generation::parameters::ThinkType::Medium,
+            ThinkType::High => ollama_rs::generation::parameters::ThinkType::High,
+        }
     }
 }


### PR DESCRIPTION
Introduce a `--think` CLI flag to control the reasoning depth of supported LLM providers (Ollama and LM Studio). This change updates the `LlmClient` trait and its implementations to pass reasoning parameters and styles streamed "thinking" blocks in dimmed text for better visual distinction.