### PR TITLE
feat: add configuration management and refactor CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +339,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +378,27 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -979,11 +1022,15 @@ dependencies = [
  "async-stream",
  "async-trait",
  "clap",
+ "directories",
  "futures",
  "lms-api",
  "ollama-rs",
+ "opener",
  "owo-colors",
+ "serde",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1005,6 +1052,25 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1131,6 +1197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1244,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opener"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
+dependencies = [
+ "bstr",
+ "dbus",
+ "normpath",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "openssl"
@@ -1213,6 +1300,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
@@ -1411,6 +1504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1798,6 +1902,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2209,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2527,6 +2679,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2728,6 +2889,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/kommit/Cargo.toml
+++ b/kommit/Cargo.toml
@@ -14,5 +14,9 @@ lms-api = { version = "0.1", path = "../lms-api", features = ["stream"]}
 ollama-rs = { version = "0.3", features = ["stream"] }
 owo-colors = "4.3.0"
 tokio = { version = "1", features = ["full"] }
+toml = "1.1.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
+serde = { version = "1.0", features = ["derive"] }
+directories = "6.0.0"
+opener = "0.7.2"

--- a/kommit/src/cli.rs
+++ b/kommit/src/cli.rs
@@ -1,27 +1,84 @@
 use crate::prompt::ResponseLang;
 use crate::provider::{LlmProvider, ThinkType};
-use clap::Parser;
+use clap::{Args as ClapArgs, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-pub(crate) struct Args {
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Commands {
+    /// Generate a commit message based on diff
+    Run(RunArgs),
+    /// Manage configuration
+    Config(ConfigArgs),
+}
+
+#[derive(ClapArgs, Debug)]
+pub(crate) struct RunArgs {
+    /// Summarize only staged changes
     #[arg(long)]
     pub(crate) staged: bool,
 
     /// Name of the model
-    #[arg(short, long, default_value = "gemma4")]
-    pub(crate) model: String,
-
-    /// Language to writing commit messages
-    #[arg(long, default_value_t = ResponseLang::En)]
-    pub(crate) lang: ResponseLang,
-
-    #[arg(long, default_value_t = LlmProvider::Ollama)]
-    pub(crate) provider: LlmProvider,
-
     #[arg(short, long)]
-    pub(crate) stream: bool,
+    pub(crate) model: Option<String>,
 
-    #[arg(short, long)]
+    /// Language for writing commit messages
+    #[arg(long)]
+    pub(crate) lang: Option<ResponseLang>,
+
+    /// LLM provider
+    #[arg(long)]
+    pub(crate) provider: Option<LlmProvider>,
+
+    /// Enable or disable streaming response
+    #[arg(short, long, value_name = "BOOL")]
+    pub(crate) stream: Option<bool>,
+
+    /// Thinking type or level
+    #[arg(short, long, value_name = "TYPE")]
     pub(crate) think: Option<ThinkType>,
+}
+
+#[derive(ClapArgs, Debug)]
+pub(crate) struct ConfigArgs {
+    #[command(subcommand)]
+    pub(crate) command: ConfigSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ConfigSubcommand {
+    /// Show the current configuration and path
+    Show,
+    /// Set a configuration value
+    Set {
+        #[command(subcommand)]
+        item: ConfigItem,
+    },
+    /// Open the configuration directory in the default file manager
+    Open,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ConfigItem {
+    Model {
+        value: String,
+    },
+    Lang {
+        value: ResponseLang,
+    },
+    Provider {
+        value: LlmProvider,
+    },
+    Stream {
+        #[arg(value_parser = ["true", "false"])]
+        value: String,
+    },
+    Think {
+        value: ThinkType,
+    },
 }

--- a/kommit/src/config.rs
+++ b/kommit/src/config.rs
@@ -1,0 +1,67 @@
+use crate::prompt::ResponseLang;
+use crate::provider::{LlmProvider, ThinkType};
+use anyhow::Context;
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tracing::{debug, warn};
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub(crate) struct Config {
+    pub(crate) model: Option<String>,
+    pub(crate) lang: Option<ResponseLang>,
+    pub(crate) provider: Option<LlmProvider>,
+    pub(crate) stream: Option<bool>,
+    pub(crate) think: Option<ThinkType>,
+}
+
+impl Config {
+    pub(crate) fn load() -> Self {
+        let config_path = Self::get_config_path();
+
+        if let Some(path) = config_path {
+            debug!(?path, "Checking for config file");
+            if path.exists() {
+                match fs::read_to_string(&path) {
+                    Ok(content) => match toml::from_str(&content) {
+                        Ok(config) => {
+                            debug!(?config, "Loaded config from file");
+                            return config;
+                        }
+                        Err(e) => {
+                            warn!(?e, "Failed to parse config file");
+                        }
+                    },
+                    Err(e) => {
+                        warn!(?e, "Failed to read config file");
+                    }
+                }
+            }
+        }
+
+        Config::default()
+    }
+
+    pub(crate) fn save(&self) -> anyhow::Result<()> {
+        let path = Self::get_config_path().context("Failed to get config path")?;
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).context("Failed to create config directory")?;
+        }
+
+        let content = toml::to_string_pretty(self).context("Failed to serialize config")?;
+        fs::write(path, content).context("Failed to write config file")?;
+
+        Ok(())
+    }
+
+    pub(crate) fn get_config_path() -> Option<PathBuf> {
+        ProjectDirs::from("", "", "kommit")
+            .map(|proj_dirs| proj_dirs.config_dir().join("config.toml"))
+    }
+
+    pub(crate) fn get_config_dir() -> Option<PathBuf> {
+        ProjectDirs::from("", "", "kommit").map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
+    }
+}

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -1,11 +1,14 @@
 pub mod cli;
+pub mod config;
 pub mod git;
 pub mod prompt;
 pub mod provider;
 
+use crate::cli::{Cli, Commands, ConfigItem, ConfigSubcommand};
+use crate::config::Config;
 use crate::git::get_diff;
-use crate::prompt::build_prompt;
-use crate::provider::{StreamResponse, create_client};
+use crate::prompt::{ResponseLang, build_prompt};
+use crate::provider::{LlmProvider, StreamResponse, create_client};
 use clap::Parser;
 use futures::StreamExt;
 use owo_colors::OwoColorize;
@@ -18,36 +21,91 @@ use tracing_subscriber::{EnvFilter, fmt};
 async fn main() -> anyhow::Result<()> {
     init_tracing();
 
-    let args = cli::Args::parse();
-    info!(?args, "Parsed arguments");
+    let cli = Cli::parse();
 
-    let client = create_client(args.provider);
+    match cli.command {
+        Commands::Run(args) => {
+            let config = Config::load();
+            info!(?args, ?config, "Running with merged config");
 
-    let diff = get_diff(args.staged)?;
-    let prompt = build_prompt(&diff, args.lang);
+            let provider = args
+                .provider
+                .or(config.provider)
+                .unwrap_or(LlmProvider::Ollama);
+            let model = args
+                .model
+                .or(config.model)
+                .unwrap_or_else(|| "gemma4".to_string());
+            let lang = args.lang.or(config.lang).unwrap_or(ResponseLang::En);
+            let stream_enabled = args.stream.or(config.stream).unwrap_or(false);
+            let think = args.think.or(config.think);
 
-    if args.stream {
-        let mut stream = client
-            .generate_stream(&args.model, &prompt, args.think)
-            .await?;
+            let client = create_client(provider);
+            let diff = get_diff(args.staged)?;
+            let prompt = build_prompt(&diff, lang);
 
-        let mut out = io::stdout().lock();
-        while let Some(res) = stream.next().await {
-            match res? {
-                StreamResponse::Think(text) => {
-                    out.write_all(text.bright_black().to_string().as_bytes())?;
-                    out.flush()?;
+            if stream_enabled {
+                let mut stream = client.generate_stream(&model, &prompt, think).await?;
+                let mut out = io::stdout().lock();
+                while let Some(res) = stream.next().await {
+                    match res? {
+                        StreamResponse::Think(text) => {
+                            out.write_all(text.bright_black().to_string().as_bytes())?;
+                            out.flush()?;
+                        }
+                        StreamResponse::Generate(text) => {
+                            out.write_all(text.as_bytes())?;
+                            out.flush()?;
+                        }
+                    }
                 }
-                StreamResponse::Generate(text) => {
-                    out.write_all(text.as_bytes())?;
-                    out.flush()?;
-                }
+                writeln!(out)?;
+            } else {
+                let message = client.generate(&model, &prompt, think).await?;
+                println!("{message}");
             }
         }
-        writeln!(out)?;
-    } else {
-        let message = client.generate(&args.model, &prompt, args.think).await?;
-        println!("{message}");
+        Commands::Config(args) => match args.command {
+            ConfigSubcommand::Show => {
+                let path = Config::get_config_path();
+                let config = Config::load();
+                println!(
+                    "Config path: {}",
+                    path.map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "Unknown".to_string())
+                );
+                println!("---");
+                println!("{}", toml::to_string_pretty(&config)?);
+            }
+            ConfigSubcommand::Set { item } => {
+                let mut config = Config::load();
+                match item {
+                    ConfigItem::Model { value } => config.model = Some(value),
+                    ConfigItem::Lang { value } => config.lang = Some(value),
+                    ConfigItem::Provider { value } => config.provider = Some(value),
+                    ConfigItem::Stream { value } => {
+                        config.stream = Some(
+                            value
+                                .parse::<bool>()
+                                .map_err(|_| anyhow::anyhow!("Invalid boolean value"))?,
+                        );
+                    }
+                    ConfigItem::Think { value } => config.think = Some(value),
+                }
+                config.save()?;
+                println!("Configuration updated successfully.");
+            }
+            ConfigSubcommand::Open => {
+                if let Some(dir) = Config::get_config_dir() {
+                    if !dir.exists() {
+                        std::fs::create_dir_all(&dir)?;
+                    }
+                    opener::open(dir)?;
+                } else {
+                    anyhow::bail!("Could not find config directory");
+                }
+            }
+        },
     }
 
     Ok(())

--- a/kommit/src/prompt.rs
+++ b/kommit/src/prompt.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use tracing::info;
 
@@ -56,7 +57,8 @@ Follow these rules strictly:
 "#
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum ResponseLang {
     Ko,
     En,

--- a/kommit/src/provider.rs
+++ b/kommit/src/provider.rs
@@ -3,13 +3,15 @@ use crate::provider::ollama::OllamaClient;
 use async_trait::async_trait;
 use clap::ValueEnum;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::pin::Pin;
 
 pub mod lmstudio;
 pub mod ollama;
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum LlmProvider {
     Ollama,
     LmStudio,
@@ -51,7 +53,8 @@ pub(crate) fn create_client(provider: LlmProvider) -> Box<dyn LlmClient> {
     }
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum ThinkType {
     True,
     False,


### PR DESCRIPTION
Introduce a persistent configuration system using TOML to store user preferences for LLM provider, model, language, and other settings.

- Refactor CLI structure to use subcommands (`run` and `config`)
- Implement `config set`, `config show`, and `config open` commands
- Merge command-line arguments with stored configuration at runtime
- Add dependencies for TOML parsing and directory management