### PR TITLE
feat: add automatic commit and push options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "opener",
  "owo-colors",
  "serde",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",

--- a/kommit/Cargo.toml
+++ b/kommit/Cargo.toml
@@ -20,3 +20,4 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"]
 serde = { version = "1.0", features = ["derive"] }
 directories = "6.0.0"
 opener = "0.7.2"
+tempfile = "3"

--- a/kommit/src/cli.rs
+++ b/kommit/src/cli.rs
@@ -42,6 +42,14 @@ pub(crate) struct RunArgs {
     /// Thinking type or level
     #[arg(short, long, value_name = "TYPE")]
     pub(crate) think: Option<ThinkType>,
+
+    /// Commit the changes after generating the message
+    #[arg(short, long)]
+    pub(crate) commit: bool,
+
+    /// Push the changes after committing
+    #[arg(short, long)]
+    pub(crate) push: bool,
 }
 
 #[derive(ClapArgs, Debug)]

--- a/kommit/src/git.rs
+++ b/kommit/src/git.rs
@@ -1,9 +1,11 @@
+use std::io::Write;
 use std::process::Command;
+use tempfile::NamedTempFile;
 use tracing::info;
 
 pub(crate) fn get_diff(staged: bool) -> anyhow::Result<String> {
     info!(%staged, "Getting diff");
-    // TODO: diff 너무 길명 truncate 필요
+    // TODO: diff 너무 길면 truncate 필요
     // TODO: binary 파일 제외
     // TODO: output이 비어있을때 처리
 
@@ -19,4 +21,29 @@ pub(crate) fn get_diff(staged: bool) -> anyhow::Result<String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub(crate) fn add_all() -> anyhow::Result<()> {
+    info!("Adding all changes");
+    Command::new("git").args(["add", "--all"]).status()?;
+    Ok(())
+}
+
+pub(crate) fn commit(message: &[u8]) -> anyhow::Result<()> {
+    info!(message = %String::from_utf8_lossy(message), "Committing with message");
+
+    let mut tmpfile = NamedTempFile::new()?;
+    tmpfile.write_all(message)?;
+
+    Command::new("git")
+        .args(["commit", "-F"])
+        .arg(tmpfile.path())
+        .status()?;
+    Ok(())
+}
+
+pub(crate) fn push() -> anyhow::Result<()> {
+    info!("Pushing");
+    Command::new("git").args(["push"]).status()?;
+    Ok(())
 }

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -4,16 +4,15 @@ pub mod git;
 pub mod prompt;
 pub mod provider;
 
-use crate::cli::{Cli, Commands, ConfigItem, ConfigSubcommand};
+use crate::cli::{Cli, Commands, ConfigArgs, ConfigItem, ConfigSubcommand, RunArgs};
 use crate::config::Config;
-use crate::git::get_diff;
+use crate::git::{add_all, commit, get_diff, push};
 use crate::prompt::{ResponseLang, build_prompt};
 use crate::provider::{LlmProvider, StreamResponse, create_client};
 use clap::Parser;
 use futures::StreamExt;
 use owo_colors::OwoColorize;
-use std::io;
-use std::io::Write;
+use std::io::{self, Write};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt};
 
@@ -24,88 +23,8 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Run(args) => {
-            let config = Config::load();
-            info!(?args, ?config, "Running with merged config");
-
-            let provider = args
-                .provider
-                .or(config.provider)
-                .unwrap_or(LlmProvider::Ollama);
-            let model = args
-                .model
-                .or(config.model)
-                .unwrap_or_else(|| "gemma4".to_string());
-            let lang = args.lang.or(config.lang).unwrap_or(ResponseLang::En);
-            let stream_enabled = args.stream.or(config.stream).unwrap_or(false);
-            let think = args.think.or(config.think);
-
-            let client = create_client(provider);
-            let diff = get_diff(args.staged)?;
-            let prompt = build_prompt(&diff, lang);
-
-            if stream_enabled {
-                let mut stream = client.generate_stream(&model, &prompt, think).await?;
-                let mut out = io::stdout().lock();
-                while let Some(res) = stream.next().await {
-                    match res? {
-                        StreamResponse::Think(text) => {
-                            out.write_all(text.bright_black().to_string().as_bytes())?;
-                            out.flush()?;
-                        }
-                        StreamResponse::Generate(text) => {
-                            out.write_all(text.as_bytes())?;
-                            out.flush()?;
-                        }
-                    }
-                }
-                writeln!(out)?;
-            } else {
-                let message = client.generate(&model, &prompt, think).await?;
-                println!("{message}");
-            }
-        }
-        Commands::Config(args) => match args.command {
-            ConfigSubcommand::Show => {
-                let path = Config::get_config_path();
-                let config = Config::load();
-                println!(
-                    "Config path: {}",
-                    path.map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|| "Unknown".to_string())
-                );
-                println!("---");
-                println!("{}", toml::to_string_pretty(&config)?);
-            }
-            ConfigSubcommand::Set { item } => {
-                let mut config = Config::load();
-                match item {
-                    ConfigItem::Model { value } => config.model = Some(value),
-                    ConfigItem::Lang { value } => config.lang = Some(value),
-                    ConfigItem::Provider { value } => config.provider = Some(value),
-                    ConfigItem::Stream { value } => {
-                        config.stream = Some(
-                            value
-                                .parse::<bool>()
-                                .map_err(|_| anyhow::anyhow!("Invalid boolean value"))?,
-                        );
-                    }
-                    ConfigItem::Think { value } => config.think = Some(value),
-                }
-                config.save()?;
-                println!("Configuration updated successfully.");
-            }
-            ConfigSubcommand::Open => {
-                if let Some(dir) = Config::get_config_dir() {
-                    if !dir.exists() {
-                        std::fs::create_dir_all(&dir)?;
-                    }
-                    opener::open(dir)?;
-                } else {
-                    anyhow::bail!("Could not find config directory");
-                }
-            }
-        },
+        Commands::Run(args) => run(args).await?,
+        Commands::Config(args) => config(args)?,
     }
 
     Ok(())
@@ -118,4 +37,113 @@ fn init_tracing() {
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+}
+
+async fn run(args: RunArgs) -> anyhow::Result<()> {
+    let config = Config::load();
+    info!(?args, ?config, "Running with merged config");
+
+    let provider = args
+        .provider
+        .or(config.provider)
+        .unwrap_or(LlmProvider::Ollama);
+    let model = args
+        .model
+        .or(config.model)
+        .unwrap_or_else(|| "gemma4".to_string());
+    let lang = args.lang.or(config.lang).unwrap_or(ResponseLang::En);
+    let stream_enabled = args.stream.or(config.stream).unwrap_or(false);
+    let think = args.think.or(config.think);
+
+    let client = create_client(provider);
+    let diff = get_diff(args.staged)?;
+    let prompt = build_prompt(&diff, lang);
+
+    let mut buffer = Vec::new();
+
+    if stream_enabled {
+        let mut stream = client.generate_stream(&model, &prompt, think).await?;
+        let mut out = io::stdout().lock();
+
+        while let Some(res) = stream.next().await {
+            match res? {
+                StreamResponse::Think(text) => {
+                    write!(&mut out, "{}", text.bright_black())?;
+                }
+                StreamResponse::Generate(text) => {
+                    write!(&mut out, "{}", text)?;
+                    write!(&mut buffer, "{}", text)?;
+                }
+            }
+        }
+        // eol
+        writeln!(out)?;
+    } else {
+        let message = client.generate(&model, &prompt, think).await?;
+        println!("{message}");
+        write!(&mut buffer, "{}", message)?;
+    }
+
+    if args.commit || args.push {
+        // TODO: 여기에 커밋메세지 승인하는 기능 넣기
+        if !args.staged {
+            add_all()?;
+        }
+
+        commit(&buffer)?;
+    }
+
+    if args.push {
+        push()?;
+    }
+
+    Ok(())
+}
+
+fn config(args: ConfigArgs) -> anyhow::Result<()> {
+    match args.command {
+        ConfigSubcommand::Show => {
+            let path = Config::get_config_path();
+            let config = Config::load();
+            println!("----------------------------------------");
+            println!(
+                "Config path: {}",
+                path.map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "Unknown".to_string())
+            );
+            println!("----------------------------------------");
+            println!("{}", toml::to_string_pretty(&config)?);
+            println!("----------------------------------------");
+        }
+        ConfigSubcommand::Set { item } => {
+            let mut config = Config::load();
+            match item {
+                ConfigItem::Model { value } => config.model = Some(value),
+                ConfigItem::Lang { value } => config.lang = Some(value),
+                ConfigItem::Provider { value } => config.provider = Some(value),
+                ConfigItem::Stream { value } => {
+                    config.stream = Some(
+                        value
+                            .parse::<bool>()
+                            .map_err(|_| anyhow::anyhow!("Invalid boolean value"))?,
+                    );
+                }
+                ConfigItem::Think { value } => config.think = Some(value),
+            }
+            config.save()?;
+            println!("Configuration updated successfully.");
+        }
+        ConfigSubcommand::Open => {
+            if let Some(dir) = Config::get_config_dir() {
+                if !dir.exists() {
+                    std::fs::create_dir_all(&dir)?;
+                }
+                opener::open(dir)?;
+            } else {
+                anyhow::bail!("Could not find config directory");
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/kommit/src/provider/lmstudio.rs
+++ b/kommit/src/provider/lmstudio.rs
@@ -3,10 +3,10 @@ use anyhow::Context;
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::StreamExt;
-use lms_api::{LmStudio, models::load::request::LoadRequestBuilder};
 use lms_api::chat::request::ChatRequestBuilder;
 use lms_api::chat::response::Output;
 use lms_api::chat::stream::response::StreamEvent;
+use lms_api::{LmStudio, models::load::request::LoadRequestBuilder};
 use std::fmt::Write;
 use tracing::{info, instrument, trace};
 
@@ -28,7 +28,8 @@ impl LmStudioClient {
             .model(model)
             .build()
             .context("failed to build load request")?;
-        self.lms.load(request)
+        self.lms
+            .load(request)
             .await
             .context("failed to load model")?;
         Ok(())
@@ -48,13 +49,14 @@ impl ProviderStrategy for LmStudioClient {
         trace!(prompt = prompt, "Generating commit message");
 
         self.load_model(model).await?;
-        
+
         let mut builder = ChatRequestBuilder::default();
         if let Some(think_type) = think {
             builder.reasoning(think_type);
         }
 
-        let res = self.lms
+        let res = self
+            .lms
             .chat(builder.model(model).input(prompt).build()?)
             .await
             .context("Failed to connect to LmStudio. Is it running?")?;


### PR DESCRIPTION
Introduce `--commit` and `--push` flags to automatically execute git commands after generating a commit message. This includes implementing helper functions for `git add`, `git commit` (via temporary files), and `git push`.