### PR TITLE
fix: handle empty git diff and commit message

### DIFF
--- a/kommit/src/git.rs
+++ b/kommit/src/git.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use std::io::Write;
 use std::process::Command;
 use tempfile::NamedTempFile;
@@ -7,7 +8,6 @@ pub(crate) fn get_diff(staged: bool) -> anyhow::Result<String> {
     info!(%staged, "Getting diff");
     // TODO: diff 너무 길면 truncate 필요
     // TODO: binary 파일 제외
-    // TODO: output이 비어있을때 처리
 
     let output = if staged {
         Command::new("git").args(["diff", "--staged"]).output()?
@@ -17,7 +17,12 @@ pub(crate) fn get_diff(staged: bool) -> anyhow::Result<String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git diff failed: {}", stderr);
+        bail!("git diff failed: {}", stderr);
+    }
+
+    // output이 비어있을때 처리
+    if output.stdout.is_empty() {
+        bail!("git diff is empty");
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -9,6 +9,7 @@ use crate::config::Config;
 use crate::git::{add_all, commit, get_diff, push};
 use crate::prompt::{ResponseLang, build_prompt};
 use crate::provider::{LlmProvider, StreamResponse, create_client};
+use anyhow::{anyhow, bail};
 use clap::Parser;
 use futures::StreamExt;
 use owo_colors::OwoColorize;
@@ -84,6 +85,12 @@ async fn run(args: RunArgs) -> anyhow::Result<()> {
         write!(&mut buffer, "{}", message)?;
     }
 
+    if buffer.is_empty() {
+        bail!(
+            "There is no message. Please check to see if the response was interrupted due to a lack of context."
+        )
+    }
+
     if args.commit || args.push {
         // TODO: 여기에 커밋메세지 승인하는 기능 넣기
         if !args.staged {
@@ -125,7 +132,7 @@ fn config(args: ConfigArgs) -> anyhow::Result<()> {
                     config.stream = Some(
                         value
                             .parse::<bool>()
-                            .map_err(|_| anyhow::anyhow!("Invalid boolean value"))?,
+                            .map_err(|_| anyhow!("Invalid boolean value"))?,
                     );
                 }
                 ConfigItem::Think { value } => config.think = Some(value),
@@ -140,7 +147,7 @@ fn config(args: ConfigArgs) -> anyhow::Result<()> {
                 }
                 opener::open(dir)?;
             } else {
-                anyhow::bail!("Could not find config directory");
+                bail!("Could not find config directory");
             }
         }
     }


### PR DESCRIPTION
Add validation to bail when the git diff is empty or when the LLM fails to generate a commit message, preventing empty commits.