### PR TITLE
feat: allow custom host and port for LLM servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/kommit/Cargo.toml
+++ b/kommit/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1.0", features = ["derive"] }
 directories = "6.0.0"
 opener = "0.7.2"
 tempfile = "3"
+url = "2.5.8"

--- a/kommit/src/cli.rs
+++ b/kommit/src/cli.rs
@@ -50,6 +50,14 @@ pub(crate) struct RunArgs {
     /// Push the changes after committing
     #[arg(short, long)]
     pub(crate) push: bool,
+
+    /// Host of the LLM server
+    #[arg(long, value_name = "HOST")]
+    pub(crate) host: Option<String>,
+
+    /// Port of the LLM server
+    #[arg(long, value_name = "PORT")]
+    pub(crate) port: Option<u16>,
 }
 
 #[derive(ClapArgs, Debug)]
@@ -88,5 +96,11 @@ pub(crate) enum ConfigItem {
     },
     Think {
         value: ThinkType,
+    },
+    Host {
+        value: String,
+    },
+    Port {
+        value: u16,
     },
 }

--- a/kommit/src/config.rs
+++ b/kommit/src/config.rs
@@ -14,6 +14,8 @@ pub(crate) struct Config {
     pub(crate) provider: Option<LlmProvider>,
     pub(crate) stream: Option<bool>,
     pub(crate) think: Option<ThinkType>,
+    pub(crate) host: Option<String>,
+    pub(crate) port: Option<u16>,
 }
 
 impl Config {

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -16,6 +16,7 @@ use owo_colors::OwoColorize;
 use std::io::{self, Write};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt};
+use url::Url;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -55,8 +56,24 @@ async fn run(args: RunArgs) -> anyhow::Result<()> {
     let lang = args.lang.or(config.lang).unwrap_or(ResponseLang::En);
     let stream_enabled = args.stream.or(config.stream).unwrap_or(false);
     let think = args.think.or(config.think);
+    let host_str = args.host.or(config.host);
+    let port = args
+        .port
+        .or(config.port)
+        .unwrap_or_else(|| provider.default_port());
 
-    let client = create_client(provider);
+    let url = if let Some(h) = host_str {
+        if h.contains("://") {
+            Url::parse(&h)?
+        } else {
+            Url::parse(&format!("http://{}", h))?
+        }
+    } else {
+        provider.default_host()
+    };
+
+    let client = create_client(provider, url, port)?;
+
     let diff = get_diff(args.staged)?;
     let prompt = build_prompt(&diff, lang);
 
@@ -136,6 +153,8 @@ fn config(args: ConfigArgs) -> anyhow::Result<()> {
                     );
                 }
                 ConfigItem::Think { value } => config.think = Some(value),
+                ConfigItem::Host { value } => config.host = Some(value),
+                ConfigItem::Port { value } => config.port = Some(value),
             }
             config.save()?;
             println!("Configuration updated successfully.");

--- a/kommit/src/provider.rs
+++ b/kommit/src/provider.rs
@@ -6,6 +6,7 @@ use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::pin::Pin;
+use url::Url;
 
 pub mod lmstudio;
 pub mod ollama;
@@ -15,6 +16,22 @@ pub mod ollama;
 pub(crate) enum LlmProvider {
     Ollama,
     LmStudio,
+}
+
+impl LlmProvider {
+    pub fn default_host(&self) -> Url {
+        match self {
+            LlmProvider::Ollama => Url::parse("http://localhost").unwrap(),
+            LlmProvider::LmStudio => Url::parse("http://localhost").unwrap(),
+        }
+    }
+
+    pub fn default_port(&self) -> u16 {
+        match self {
+            LlmProvider::Ollama => 11434,
+            LlmProvider::LmStudio => 1234,
+        }
+    }
 }
 
 impl Display for LlmProvider {
@@ -46,10 +63,14 @@ pub(crate) trait ProviderStrategy {
     ) -> anyhow::Result<LlmStream>;
 }
 
-pub(crate) fn create_client(provider: LlmProvider) -> Box<dyn ProviderStrategy> {
+pub(crate) fn create_client(
+    provider: LlmProvider,
+    host: Url,
+    port: u16,
+) -> anyhow::Result<Box<dyn ProviderStrategy>> {
     match provider {
-        LlmProvider::Ollama => Box::new(OllamaClient::new()),
-        LlmProvider::LmStudio => Box::new(LmStudioClient::new()),
+        LlmProvider::Ollama => Ok(Box::new(OllamaClient::new(host, port)?)),
+        LlmProvider::LmStudio => Ok(Box::new(LmStudioClient::new(host, port)?)),
     }
 }
 

--- a/kommit/src/provider/lmstudio.rs
+++ b/kommit/src/provider/lmstudio.rs
@@ -9,16 +9,18 @@ use lms_api::chat::stream::response::StreamEvent;
 use lms_api::{LmStudio, models::load::request::LoadRequestBuilder};
 use std::fmt::Write;
 use tracing::{info, instrument, trace};
+use url::Url;
 
+#[derive(Default)]
 pub(crate) struct LmStudioClient {
     lms: LmStudio,
 }
 
 impl LmStudioClient {
-    pub(crate) fn new() -> Self {
-        Self {
-            lms: LmStudio::default(),
-        }
+    pub(crate) fn new(host: Url, port: u16) -> anyhow::Result<Self> {
+        Ok(Self {
+            lms: LmStudio::new(host, port)?,
+        })
     }
 
     async fn load_model(&self, model: &str) -> anyhow::Result<()> {

--- a/kommit/src/provider/ollama.rs
+++ b/kommit/src/provider/ollama.rs
@@ -6,12 +6,18 @@ use futures::StreamExt;
 use ollama_rs::Ollama;
 use ollama_rs::generation::completion::request::GenerationRequest;
 use tracing::{info, instrument, trace};
+use url::Url;
 
-pub(crate) struct OllamaClient {}
+#[derive(Default)]
+pub(crate) struct OllamaClient {
+    client: Ollama,
+}
 
 impl OllamaClient {
-    pub(crate) fn new() -> Self {
-        Self {}
+    pub(crate) fn new(host: Url, port: u16) -> anyhow::Result<Self> {
+        Ok(Self {
+            client: Ollama::new(host, port),
+        })
     }
 }
 
@@ -27,13 +33,13 @@ impl ProviderStrategy for OllamaClient {
         info!("Generating commit message");
         trace!(prompt = prompt, "Generating commit message");
 
-        let ollama = Ollama::default();
         let mut request = GenerationRequest::new(model.to_string(), prompt);
         if let Some(think_type) = think {
             request = request.think(think_type);
         }
 
-        let res = ollama
+        let res = self
+            .client
             .generate(request)
             .await
             .context("Failed to connect to Ollama. Is it running?")?;
@@ -51,13 +57,13 @@ impl ProviderStrategy for OllamaClient {
         info!("Generating commit message stream");
         trace!(prompt = prompt, "Generating commit message stream");
 
-        let ollama = Ollama::default();
         let mut request = GenerationRequest::new(model.to_string(), prompt);
         if let Some(think_type) = think {
             request = request.think(think_type);
         }
 
-        let stream = ollama
+        let stream = self
+            .client
             .generate_stream(request)
             .await
             .context("Failed to connect to Ollama. Is it running?")?;


### PR DESCRIPTION
Add CLI flags and configuration options to specify the LLM server's host and port, allowing users to connect to remote or non-default instances.