### PR TITLE
feat: add option to edit generated commit message

### DIFF
--- a/kommit/src/cli.rs
+++ b/kommit/src/cli.rs
@@ -58,6 +58,10 @@ pub(crate) struct RunArgs {
     /// Port of the LLM server
     #[arg(long, value_name = "PORT")]
     pub(crate) port: Option<u16>,
+
+    /// Edit the generated commit message before committing
+    #[arg(short, long)]
+    pub(crate) edit: bool,
 }
 
 #[derive(ClapArgs, Debug)]

--- a/kommit/src/git.rs
+++ b/kommit/src/git.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{Context, bail};
 use std::io::Write;
 use std::process::Command;
 use tempfile::NamedTempFile;
@@ -34,15 +34,12 @@ pub(crate) fn add_all() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) fn commit(message: &[u8]) -> anyhow::Result<()> {
-    info!(message = %String::from_utf8_lossy(message), "Committing with message");
-
-    let mut tmpfile = NamedTempFile::new()?;
-    tmpfile.write_all(message)?;
+pub(crate) fn commit(file: &NamedTempFile) -> anyhow::Result<()> {
+    info!(file = %file.path().display(), "Committing with message");
 
     Command::new("git")
         .args(["commit", "-F"])
-        .arg(tmpfile.path())
+        .arg(file.path())
         .status()?;
     Ok(())
 }
@@ -51,4 +48,39 @@ pub(crate) fn push() -> anyhow::Result<()> {
     info!("Pushing");
     Command::new("git").args(["push"]).status()?;
     Ok(())
+}
+
+pub(crate) fn save_buffer_to_tempfile(buffer: &[u8]) -> anyhow::Result<NamedTempFile> {
+    let mut tempfile = NamedTempFile::new().context("Cannot create new NamedTempFile")?;
+    tempfile
+        .write_all(buffer)
+        .context("Failed to write buffer to tempfile")?;
+    Ok(tempfile)
+}
+
+pub(crate) fn edit_commit_message(file: &NamedTempFile) -> anyhow::Result<()> {
+    info!(file = %file.path().display(), "Edit commit message by editor");
+
+    let editor_env = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vim".to_string());
+
+    let mut iter = editor_env.split_whitespace();
+    let editor_binary = iter.next().unwrap_or("vim");
+
+    let mut cmd = Command::new(editor_binary);
+    for arg in iter {
+        cmd.arg(arg);
+    }
+
+    let status = cmd
+        .arg(file.path())
+        .status()
+        .context("Failed to execute editor process")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("Editor exited with non-zero status");
+    }
 }

--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -6,10 +6,10 @@ pub mod provider;
 
 use crate::cli::{Cli, Commands, ConfigArgs, ConfigItem, ConfigSubcommand, RunArgs};
 use crate::config::Config;
-use crate::git::{add_all, commit, get_diff, push};
+use crate::git::{add_all, commit, edit_commit_message, get_diff, push, save_buffer_to_tempfile};
 use crate::prompt::{ResponseLang, build_prompt};
 use crate::provider::{LlmProvider, StreamResponse, create_client};
-use anyhow::{anyhow, bail};
+use anyhow::{Context, anyhow, bail};
 use clap::Parser;
 use futures::StreamExt;
 use owo_colors::OwoColorize;
@@ -109,12 +109,18 @@ async fn run(args: RunArgs) -> anyhow::Result<()> {
     }
 
     if args.commit || args.push {
-        // TODO: 여기에 커밋메세지 승인하는 기능 넣기
+        let tempfile =
+            save_buffer_to_tempfile(&buffer).context("Failed to save buffer to tempfile")?;
+
+        if args.edit {
+            edit_commit_message(&tempfile).context("Failed to edit commit message")?;
+        }
+
         if !args.staged {
             add_all()?;
         }
 
-        commit(&buffer)?;
+        commit(&tempfile)?;
     }
 
     if args.push {


### PR DESCRIPTION
Introduce an `--edit` flag that allows users to review and manually refine the AI-generated commit message using their preferred text editor before finalizing the commit.