### PR TITLE
fix: explicitly signal end of thinking phase

### DIFF
--- a/kommit/src/main.rs
+++ b/kommit/src/main.rs
@@ -88,6 +88,9 @@ async fn run(args: RunArgs) -> anyhow::Result<()> {
                 StreamResponse::Think(text) => {
                     write!(&mut out, "{}", text.bright_black())?;
                 }
+                StreamResponse::ThinkDone => {
+                    writeln!(&mut out, "\n\n")?;
+                }
                 StreamResponse::Generate(text) => {
                     write!(&mut out, "{}", text)?;
                     write!(&mut buffer, "{}", text)?;

--- a/kommit/src/provider.rs
+++ b/kommit/src/provider.rs
@@ -42,6 +42,7 @@ impl Display for LlmProvider {
 
 pub(crate) enum StreamResponse {
     Think(String),
+    ThinkDone,
     Generate(String),
 }
 

--- a/kommit/src/provider/lmstudio.rs
+++ b/kommit/src/provider/lmstudio.rs
@@ -122,7 +122,7 @@ impl ProviderStrategy for LmStudioClient {
                     }
                     StreamEvent::ReasoningEnd => {
 
-                        yield Ok(StreamResponse::Think("\n\n\n".to_string()));
+                        yield Ok(StreamResponse::ThinkDone);
                     }
                     StreamEvent::MessageDelta { content } => {
                         info!(content = %content, event = "message.delta");

--- a/kommit/src/provider/ollama.rs
+++ b/kommit/src/provider/ollama.rs
@@ -69,6 +69,7 @@ impl ProviderStrategy for OllamaClient {
             .context("Failed to connect to Ollama. Is it running?")?;
 
         let mut stream = Box::pin(stream);
+        let mut is_thinking = false;
 
         let s = stream! {
             while let Some(res) = stream.next().await {
@@ -76,8 +77,13 @@ impl ProviderStrategy for OllamaClient {
                     Ok(responses) => {
                         for res in responses {
                             if let Some(thinking) = res.thinking {
+                                is_thinking = true;
                                 yield Ok(StreamResponse::Think(thinking));
                             } else {
+                                if is_thinking {
+                                    is_thinking = false;
+                                    yield Ok(StreamResponse::ThinkDone);
+                                }
                                 yield Ok(StreamResponse::Generate(res.response));
                             }
                         }


### PR DESCRIPTION
Add ThinkDone variant to StreamResponse to allow providers to consistently notify when the reasoning phase has finished.